### PR TITLE
Fix Mist style with sub menu

### DIFF
--- a/source/css/_schemes/Mist/_posts-expand.styl
+++ b/source/css/_schemes/Mist/_posts-expand.styl
@@ -27,7 +27,7 @@
     display: none;
   }
 
-  .post-block:not(:first-child) {
+  .post-block:not(:first-of-type) {
     margin-top: 120px;
   }
 


### PR DESCRIPTION
When the sub menu exists, there is too large space between the sub menu and the post block.

<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved:

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
